### PR TITLE
Make ALB logs for IPFS optional

### DIFF
--- a/examples/ecs/main.tf
+++ b/examples/ecs/main.tf
@@ -34,6 +34,7 @@ module "ceramic_ecs" {
   ipfs_cpu                       = var.ipfs_cpu
   ipfs_debug_env_var             = var.ipfs_debug_env_var
   ipfs_domain_name               = var.domain_name
+  ipfs_enable_alb_logging        = true
   ipfs_memory                    = var.ipfs_memory
   ipfs_task_count                = var.ipfs_task_count
   private_subnet_ids             = data.aws_subnet_ids.private.ids

--- a/modules/ecs/ipfs/load_balancers.tf
+++ b/modules/ecs/ipfs/load_balancers.tf
@@ -12,7 +12,7 @@ resource "aws_lb" "external" {
   access_logs {
     bucket  = module.s3_alb.this_s3_bucket_id
     prefix  = "external"
-    enabled = true
+    enabled = var.enable_alb_logging
   }
 
   tags = local.default_tags

--- a/modules/ecs/ipfs/storage.tf
+++ b/modules/ecs/ipfs/storage.tf
@@ -2,7 +2,7 @@ module "s3_alb" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "1.25.0"
 
-  create_bucket = true
+  create_bucket = var.enable_alb_logging
 
   bucket = "${local.namespace}-alb.logs"
   acl    = "private"

--- a/modules/ecs/ipfs/variables.tf
+++ b/modules/ecs/ipfs/variables.tf
@@ -116,6 +116,11 @@ variable "vpc_security_group_id" {
 
 /* Specified */
 
+variable "enable_alb_logging" {
+  type        = bool
+  description = "True to create an S3 bucket to store ALB logs"
+}
+
 variable "enable_external_api" {
   type        = bool
   description = "True to enable IPFS API on external ALB"

--- a/modules/ecs/ipfs/variables.tf
+++ b/modules/ecs/ipfs/variables.tf
@@ -118,7 +118,7 @@ variable "vpc_security_group_id" {
 
 variable "enable_alb_logging" {
   type        = bool
-  description = "True to create an S3 bucket to store ALB logs"
+  description = "True to enable ALB logs (stored in a new S3 bucket)"
 }
 
 variable "enable_external_api" {

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -48,6 +48,7 @@ module "ipfs" {
   ecs_cpu                 = var.ipfs_cpu
   ecs_log_group_name      = aws_cloudwatch_log_group.ceramic.name
   ecs_memory              = var.ipfs_memory
+  enable_alb_logging      = var.ipfs_enable_alb_logging
   enable_external_api     = false
   enable_internal_api     = true
   enable_external_gateway = false

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -1,4 +1,4 @@
-/***** Common *****/
+/* Common */
 
 variable "acm_certificate_arn" {
   type        = string
@@ -65,7 +65,7 @@ variable "vpc_cidr_block" {
   description = "Default CIDR block of the VPC"
 }
 
-/***** Ceramic *****/
+/* Ceramic */
 
 variable "ceramic_anchor_service_api_url" {
   type        = string

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -75,7 +75,7 @@ variable "ceramic_anchor_service_api_url" {
 variable "ceramic_cors_allowed_origins" {
   type        = string
   description = "Web browser CORS allowed origins as stringified regex"
-  default = ".*"
+  default     = ".*"
 }
 
 variable "ceramic_cpu" {
@@ -143,7 +143,7 @@ variable "ipfs_domain_name" {
 
 variable "ipfs_enable_alb_logging" {
   type        = bool
-  description = "True to create an S3 bucket to store ALB logs"
+  description = "True to enable ALB logs (stored in a new S3 bucket)"
   default     = false
 }
 

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -141,6 +141,12 @@ variable "ipfs_domain_name" {
   description = "Domain name, including TLD"
 }
 
+variable "ipfs_enable_alb_logging" {
+  type        = bool
+  description = "True to create an S3 bucket to store ALB logs"
+  default     = false
+}
+
 variable "ipfs_memory" {
   type        = number
   description = "Memory allocation per IPFS API instance"

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -144,7 +144,7 @@ variable "ipfs_domain_name" {
 variable "ipfs_enable_alb_logging" {
   type        = bool
   description = "True to enable ALB logs (stored in a new S3 bucket)"
-  default     = false
+  default     = true
 }
 
 variable "ipfs_memory" {


### PR DESCRIPTION
Logging for the IPFS external load balancer can now be disabled by setting
```
ipfs_enable_alb_logging = false
```
