### PR TITLE
Configure IPFS storage backends for ECS

### DIFF
--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -50,7 +50,6 @@ resource "aws_ecs_task_definition" "main" {
       region            = var.aws_region
 
       ceramic_network     = var.ceramic_network
-      directory_namespace = var.directory_namespace
       enable_api          = true
       enable_gateway      = true
       enable_pubsub       = var.enable_pubsub
@@ -67,7 +66,7 @@ resource "aws_ecs_task_definition" "main" {
       s3_bucket_name       = var.s3_bucket_name
       s3_access_key_id     = module.ecs_ipfs_task_user.this_iam_access_key_id
       s3_secret_access_key = module.ecs_ipfs_task_user.this_iam_access_key_secret
-      ipfs_path            = var.ipfs_path
+      ipfs_path            = var.directory_namespace != "" ? "${var.directory_namespace}/ipfs" : "ipfs" 
       root_backend         = var.root_backend
       blocks_backend       = var.blocks_backend
       keys_backend         = var.keys_backend

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -67,6 +67,12 @@ resource "aws_ecs_task_definition" "main" {
       s3_bucket_name       = var.s3_bucket_name
       s3_access_key_id     = module.ecs_ipfs_task_user.this_iam_access_key_id
       s3_secret_access_key = module.ecs_ipfs_task_user.this_iam_access_key_secret
+      ipfs_path            = var.ipfs_path
+      root_backend         = var.root_backend
+      blocks_backend       = var.blocks_backend
+      keys_backend         = var.keys_backend
+      pins_backend         = var.pins_backend
+      datastore_backend    = var.datastore_backend
     }
   )
 

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -64,23 +64,23 @@
             },
             {
                 "name": "IPFS_BACKEND_ROOT",
-                "value": "s3"
+                "value": "${root_backend}"
             },
             {
                 "name": "IPFS_BACKEND_BLOCKS",
-                "value": "s3"
+                "value": "${blocks_backend}"
             },
             {
                 "name": "IPFS_BACKEND_KEYS",
-                "value": "s3"
+                "value": "${keys_backend}"
             },
             {
                 "name": "IPFS_BACKEND_PINS",
-                "value": "s3"
+                "value": "${pins_backend}"
             },
             {
                 "name": "IPFS_BACKEND_DATASTORE",
-                "value": "s3"
+                "value": "${datastore_backend}"
             },
             {
                 "name": "IPFS_ENABLE_API",
@@ -104,7 +104,7 @@
             },
             {
                 "name": "IPFS_PATH",
-                "value": "${directory_namespace}/ipfs"
+                "value": "${ipfs_path}"
             },
             {
                 "name": "IPFS_SWARM_TCP_PORT",

--- a/modules/ecs/ipfs/variables.tf
+++ b/modules/ecs/ipfs/variables.tf
@@ -171,3 +171,28 @@ variable "image_tag" {
   type        = string
   description = "Image tag"
 }
+
+variable "root_backend" {
+  type        = string
+  description = "Location to store IPFS repo. Use 's3' for persistence, or 'default' for advanced use cases."
+}
+
+variable "blocks_backend" {
+  type        = string
+  description = "Location to store IPFS blocks. Use 's3' for persistence, or 'default' for advanced use cases."
+}
+
+variable "keys_backend" {
+  type        = string
+  description = "Location to store IPFS keys. Use 's3' for persistence, or 'default' for advanced use cases."
+}
+
+variable "pins_backend" {
+  type        = string
+  description = "Location to store IPFS pins. Use 's3' for persistence, or 'default' for advanced use cases."
+}
+
+variable "datastore_backend" {
+  type        = string
+  description = "Location to store IPFS datastore. Use 's3' for persistence, or 'default' for advanced use cases."
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -62,6 +62,11 @@ module "ipfs" {
   public_subnet_ids       = var.public_subnet_ids
   s3_bucket_arn           = data.aws_s3_bucket.main.arn
   s3_bucket_name          = data.aws_s3_bucket.main.id
+  root_backend            = var.ipfs_root_backend
+  blocks_backend          = var.ipfs_blocks_backend
+  datstore_backend        = var.ipfs_datastore_backend
+  keys_backend            = var.ipfs_keys_backend
+  pins_backend            = var.ipfs_pins_backend
   use_ssl                 = true
   vpc_cidr_block          = var.vpc_cidr_block
   vpc_id                  = var.vpc_id

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -158,3 +158,33 @@ variable "ipfs_task_count" {
   description = "Number of IPFS ECS tasks to run in the ECS service"
   default     = 1
 }
+
+variable "ipfs_root_backend" {
+  type        = string
+  description = "Location to store IPFS repo. Use 's3' for persistence, or 'default' for advanced use cases."
+  default     = "s3"
+}
+
+variable "ipfs_blocks_backend" {
+  type        = string
+  description = "Location to store IPFS blocks. Use 's3' for persistence, or 'default' for advanced use cases."
+  default     = "s3"
+}
+
+variable "ipfs_datastore_backend" {
+  type        = string
+  description = "Location to store IPFS datastore. Use 's3' for persistence, or 'default' for advanced use cases."
+  default     = "s3"
+}
+
+variable "ipfs_keys_backend" {
+  type        = string
+  description = "Location to store IPFS keys. Use 's3' for persistence, or 'default' for advanced use cases."
+  default     = "s3"
+}
+
+variable "ipfs_pins_backend" {
+  type        = string
+  description = "Location to store IPFS pins. Use 's3' for persistence, or 'default' for advanced use cases."
+  default     = "s3"
+}


### PR DESCRIPTION
This PR makes it possible to change the storage location of the IPFS repo.

By default, the entire IPFS repo will continue to be stored in S3. This is the recommended setting.

- _There may be rare situations in which you do not need the entirety of the IPFS repo to be persistent. In these cases `default` may be used to store a part of the repo on disk rather than in S3. **This is an advanced use case that WILL RESULT IN DATA LOSS.**_