### PR TITLE
Ceramic v2 compatibility

### DIFF
--- a/modules/ecs/ipfs/load_balancers.tf
+++ b/modules/ecs/ipfs/load_balancers.tf
@@ -125,7 +125,7 @@ resource "aws_lb_target_group" "gateway" {
 /* Swarm Websocket */
 
 resource "aws_lb_listener" "swarm_ws_http" {
-  count = ! var.use_ssl ? 1 : 0
+  count = 1
 
   load_balancer_arn = aws_lb.external.arn
   port              = local.swarm_ws_port
@@ -141,13 +141,13 @@ resource "aws_lb_listener" "swarm_ws_https" {
   count = var.use_ssl ? 1 : 0
 
   load_balancer_arn = aws_lb.external.arn
-  port              = local.swarm_ws_port
+  port              = local.swarm_wss_port
   protocol          = "HTTPS"
   certificate_arn   = var.acm_certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.swarm_ws.arn
+    target_group_arn = aws_lb_target_group.swarm_wss.arn
   }
 }
 
@@ -156,6 +156,27 @@ resource "aws_lb_target_group" "swarm_ws" {
   name_prefix = "swws-"
   protocol    = "HTTP"
   port        = local.swarm_ws_port
+  target_type = "ip"
+  health_check {
+    interval            = 60
+    timeout             = 30
+    path                = "/"
+    port                = local.healthcheck_port
+    matcher             = "200"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = local.default_tags
+
+  depends_on = [aws_lb.external]
+}
+
+resource "aws_lb_target_group" "swarm_wss" {
+  vpc_id      = var.vpc_id
+  name_prefix = "swwss-"
+  protocol    = "HTTP"
+  port        = local.swarm_wss_port
   target_type = "ip"
   health_check {
     interval            = 60
@@ -230,6 +251,20 @@ module "alb_internal" {
         healthy_threshold   = 2
         unhealthy_threshold = 3
       }
+    },
+    {
+      name_prefix      = "swwss-"
+      backend_protocol = "HTTP"
+      backend_port     = local.swarm_wss_port
+      target_type      = "ip"
+      health_check = {
+        interval            = 30
+        path                = "/"
+        port                = local.healthcheck_port
+        matcher             = "200"
+        healthy_threshold   = 2
+        unhealthy_threshold = 3
+      }
     }
   ]
 
@@ -252,7 +287,14 @@ module "alb_internal" {
       target_group_index = 2
       action_type        = "forward"
     }
-  ] : []
+  ] : [
+    {
+      port               = local.swarm_ws_port
+      protocol           = "HTTP"
+      target_group_index = 2
+      action_type        = "forward"
+    }
+  ]
 
   https_listeners = var.use_ssl ? [
     {
@@ -268,10 +310,10 @@ module "alb_internal" {
       target_group_index = 1
     },
     {
-      port               = local.swarm_ws_port
+      port               = local.swarm_wss_port
       protocol           = "HTTPS"
       certificate_arn    = var.acm_certificate_arn
-      target_group_index = 2
+      target_group_index = 3
     }
   ] : []
 

--- a/modules/ecs/ipfs/locals.tf
+++ b/modules/ecs/ipfs/locals.tf
@@ -6,10 +6,10 @@ locals {
   api_port         = 5011
   gateway_port     = 9011
   healthcheck_port = 8011
-  swarm_port       = 4011
-  swarm_ws_port    = 4012
+  swarm_ws_port    = 4011
+  swarm_wss_port   = 4012
 
-  announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_ws_port}/wss" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws"
+  announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_wss_port}/wss,/dns4/${local.domain_name_external}/tcp/${local.swarm_ws_port}/ws" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws"
   domain_name_external  = "ipfs-${var.base_namespace}-external.${var.domain}"
   domain_name_internal  = "ipfs-${var.base_namespace}-internal.${var.domain}"
 

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -57,7 +57,8 @@ resource "aws_ecs_task_definition" "main" {
       api_port              = local.api_port
       gateway_port          = local.gateway_port
       healthcheck_port      = local.healthcheck_port
-      swarm_ws_port         = local.swarm_ws_port
+      swarm_tcp_port        = local.swarm_ws_port
+      swarm_ws_port         = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
       announce_address_list = local.announce_address_list
       dht_server_mode       = var.dht_server_mode
       debug                 = var.debug

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -59,6 +59,7 @@ resource "aws_ecs_task_definition" "main" {
       healthcheck_port      = local.healthcheck_port
       swarm_tcp_port        = local.swarm_ws_port
       swarm_ws_port         = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
+      swarm_wss_port        = local.swarm_wss_port
       announce_address_list = local.announce_address_list
       dht_server_mode       = var.dht_server_mode
       debug                 = var.debug

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -57,7 +57,6 @@ resource "aws_ecs_task_definition" "main" {
       api_port              = local.api_port
       gateway_port          = local.gateway_port
       healthcheck_port      = local.healthcheck_port
-      swarm_port            = local.swarm_port
       swarm_ws_port         = local.swarm_ws_port
       announce_address_list = local.announce_address_list
       dht_server_mode       = var.dht_server_mode

--- a/modules/ecs/ipfs/security_groups.tf
+++ b/modules/ecs/ipfs/security_groups.tf
@@ -30,6 +30,13 @@ resource "aws_security_group" "alb_external" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
+  ingress {
+    from_port   = local.swarm_wss_port
+    to_port     = local.swarm_wss_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   ingress {
     from_port   = 80
@@ -44,6 +51,7 @@ resource "aws_security_group" "alb_external" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
   egress {
     from_port   = 0
     to_port     = 0
@@ -86,6 +94,13 @@ resource "aws_security_group" "alb_internal" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
+  ingress {
+    from_port   = local.swarm_wss_port
+    to_port     = local.swarm_wss_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   ingress {
     from_port   = 80
@@ -100,6 +115,7 @@ resource "aws_security_group" "alb_internal" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
   egress {
     from_port   = 0
     to_port     = 0

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -15,7 +15,7 @@
                 "containerPort": ${healthcheck_port}
             },
             {
-                "containerPort": ${swarm_ws_port}
+                "containerPort": ${swarm_tcp_port}
             },
             {
                 "containerPort": ${swarm_wss_port}

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -108,7 +108,7 @@
             },
             {
                 "name": "IPFS_SWARM_TCP_PORT",
-                "value": "${swarm_ws_port}"
+                "value": "${swarm_tcp_port}"
             },
             {
                 "name": "IPFS_SWARM_WS_PORT",

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -15,10 +15,10 @@
                 "containerPort": ${healthcheck_port}
             },
             {
-                "containerPort": ${swarm_ws_port}
+                "containerPort": ${swarm_tcp_port}
             },
             {
-                "containerPort": ${swarm_wss_port}
+                "containerPort": ${swarm_ws_port}
             }
         ],
         "environment": [

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -15,10 +15,10 @@
                 "containerPort": ${healthcheck_port}
             },
             {
-                "containerPort": ${swarm_port}
+                "containerPort": ${swarm_ws_port}
             },
             {
-                "containerPort": ${swarm_ws_port}
+                "containerPort": ${swarm_wss_port}
             }
         ],
         "environment": [
@@ -108,7 +108,7 @@
             },
             {
                 "name": "IPFS_SWARM_TCP_PORT",
-                "value": "${swarm_port}"
+                "value": "${swarm_ws_port}"
             },
             {
                 "name": "IPFS_SWARM_WS_PORT",

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -15,10 +15,10 @@
                 "containerPort": ${healthcheck_port}
             },
             {
-                "containerPort": ${swarm_tcp_port}
+                "containerPort": ${swarm_ws_port}
             },
             {
-                "containerPort": ${swarm_ws_port}
+                "containerPort": ${swarm_wss_port}
             }
         ],
         "environment": [


### PR DESCRIPTION
**TODO: Ensure that we can connect over 4011/ws and 4012/wss**

---

To ensure that Ceramic v1 nodes (js-ipfs) can reach and be reached by Ceramic v2 nodes (go-ipfs), we enable swarm connections over both secure and insecure websocket ports.

Ceramic v2 IPFS nodes can only connect to the _insecure_ websocket address (until [support for secure websockets](https://github.com/libp2p/go-ws-transport/commit/d58294714ec497fba4619773886a606549144df4) is added to go-ipfs).

## SSL Enabled

IPFS nodes will be configured with swarm addresses that look like

```go
/ip4/.../tcp/4011
/ip4/.../tcp/4012/ws
```

and they will announce addresses that look like

```go
/dns4/.../tcp/4011/ws
/dns4/.../tcp/4012/wss
```

## SSL Disabled

IPFS nodes will be configured with swarm addresses that look like

```go
/ip4/.../tcp/4011
/ip4/.../tcp/4011/ws
```

and they will announce addresses that look like

```go
/dns4/.../tcp/4011/ws
```

## References
- See [Ceramic v1 ipfs-daemon config](https://github.com/ceramicnetwork/js-ceramic/blob/1.x-colorless/packages/ipfs-daemon/src/ipfs-daemon.ts#L167-L170)