### PR TITLE
Ceramic v2 compatibility

### DIFF
--- a/examples/ecs/variables.tf
+++ b/examples/ecs/variables.tf
@@ -100,7 +100,7 @@ variable "ceramic_anchor_service_api_url" {
 variable "ceramic_cors_allowed_origins" {
   type        = string
   description = "Web browser CORS allowed origins as stringified regex"
-  default = ".*"
+  default     = ".*"
 }
 
 variable "ceramic_cpu" {

--- a/modules/ecs/ipfs/load_balancers.tf
+++ b/modules/ecs/ipfs/load_balancers.tf
@@ -125,7 +125,7 @@ resource "aws_lb_target_group" "gateway" {
 /* Swarm Websocket */
 
 resource "aws_lb_listener" "swarm_ws_http" {
-  count = ! var.use_ssl ? 1 : 0
+  count = 1
 
   load_balancer_arn = aws_lb.external.arn
   port              = local.swarm_ws_port
@@ -141,13 +141,13 @@ resource "aws_lb_listener" "swarm_ws_https" {
   count = var.use_ssl ? 1 : 0
 
   load_balancer_arn = aws_lb.external.arn
-  port              = local.swarm_ws_port
+  port              = local.swarm_wss_port
   protocol          = "HTTPS"
   certificate_arn   = var.acm_certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.swarm_ws.arn
+    target_group_arn = aws_lb_target_group.swarm_wss.arn
   }
 }
 
@@ -156,6 +156,27 @@ resource "aws_lb_target_group" "swarm_ws" {
   name_prefix = "swws-"
   protocol    = "HTTP"
   port        = local.swarm_ws_port
+  target_type = "ip"
+  health_check {
+    interval            = 60
+    timeout             = 30
+    path                = "/"
+    port                = local.healthcheck_port
+    matcher             = "200"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = local.default_tags
+
+  depends_on = [aws_lb.external]
+}
+
+resource "aws_lb_target_group" "swarm_wss" {
+  vpc_id      = var.vpc_id
+  name_prefix = "swwss-"
+  protocol    = "HTTP"
+  port        = local.swarm_wss_port
   target_type = "ip"
   health_check {
     interval            = 60
@@ -230,6 +251,20 @@ module "alb_internal" {
         healthy_threshold   = 2
         unhealthy_threshold = 3
       }
+    },
+    {
+      name_prefix      = "swwss-"
+      backend_protocol = "HTTP"
+      backend_port     = local.swarm_wss_port
+      target_type      = "ip"
+      health_check = {
+        interval            = 30
+        path                = "/"
+        port                = local.healthcheck_port
+        matcher             = "200"
+        healthy_threshold   = 2
+        unhealthy_threshold = 3
+      }
     }
   ]
 
@@ -252,7 +287,14 @@ module "alb_internal" {
       target_group_index = 2
       action_type        = "forward"
     }
-  ] : []
+  ] : [
+    {
+      port               = local.swarm_ws_port
+      protocol           = "HTTP"
+      target_group_index = 2
+      action_type        = "forward"
+    }
+  ]
 
   https_listeners = var.use_ssl ? [
     {
@@ -268,10 +310,10 @@ module "alb_internal" {
       target_group_index = 1
     },
     {
-      port               = local.swarm_ws_port
+      port               = local.swarm_wss_port
       protocol           = "HTTPS"
       certificate_arn    = var.acm_certificate_arn
-      target_group_index = 2
+      target_group_index = 3
     }
   ] : []
 

--- a/modules/ecs/ipfs/load_balancers.tf
+++ b/modules/ecs/ipfs/load_balancers.tf
@@ -122,10 +122,46 @@ resource "aws_lb_target_group" "gateway" {
   depends_on = [aws_lb.external]
 }
 
+/* Swarm TCP */
+
+resource "aws_lb_listener" "swarm_tcp_http" {
+  count = 1
+
+  load_balancer_arn = aws_lb.external.arn
+  port              = local.swarm_tcp_port
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.swarm_tcp.arn
+  }
+}
+
+resource "aws_lb_target_group" "swarm_tcp" {
+  vpc_id      = var.vpc_id
+  name_prefix = "sw-"
+  protocol    = "HTTP"
+  port        = local.swarm_tcp_port
+  target_type = "ip"
+  health_check {
+    interval            = 60
+    timeout             = 30
+    path                = "/"
+    port                = local.healthcheck_port
+    matcher             = "200"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = local.default_tags
+
+  depends_on = [aws_lb.external]
+}
+
 /* Swarm Websocket */
 
 resource "aws_lb_listener" "swarm_ws_http" {
-  count = 1
+  count = var.use_ssl ? 0 : 1
 
   load_balancer_arn = aws_lb.external.arn
   port              = local.swarm_ws_port
@@ -239,6 +275,20 @@ module "alb_internal" {
       }
     },
     {
+      name_prefix      = "sw-"
+      backend_protocol = "HTTP"
+      backend_port     = local.swarm_tcp_port
+      target_type      = "ip"
+      health_check = {
+        interval            = 30
+        path                = "/"
+        port                = local.healthcheck_port
+        matcher             = "200"
+        healthy_threshold   = 2
+        unhealthy_threshold = 3
+      }
+    },
+    {
       name_prefix      = "swws-"
       backend_protocol = "HTTP"
       backend_port     = local.swarm_ws_port
@@ -284,12 +334,12 @@ module "alb_internal" {
     {
       port               = local.swarm_ws_port
       protocol           = "HTTP"
-      target_group_index = 2
+      target_group_index = 3
       action_type        = "forward"
     }
-  ] : [
+    ] : [
     {
-      port               = local.swarm_ws_port
+      port               = local.swarm_tcp_port
       protocol           = "HTTP"
       target_group_index = 2
       action_type        = "forward"
@@ -313,7 +363,7 @@ module "alb_internal" {
       port               = local.swarm_wss_port
       protocol           = "HTTPS"
       certificate_arn    = var.acm_certificate_arn
-      target_group_index = 3
+      target_group_index = 4
     }
   ] : []
 

--- a/modules/ecs/ipfs/load_balancers.tf
+++ b/modules/ecs/ipfs/load_balancers.tf
@@ -177,13 +177,13 @@ resource "aws_lb_listener" "swarm_ws_https" {
   count = var.use_ssl ? 1 : 0
 
   load_balancer_arn = aws_lb.external.arn
-  port              = local.swarm_wss_port
+  port              = local.swarm_ws_port
   protocol          = "HTTPS"
   certificate_arn   = var.acm_certificate_arn
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.swarm_wss.arn
+    target_group_arn = aws_lb_target_group.swarm_ws.arn
   }
 }
 
@@ -192,27 +192,6 @@ resource "aws_lb_target_group" "swarm_ws" {
   name_prefix = "swws-"
   protocol    = "HTTP"
   port        = local.swarm_ws_port
-  target_type = "ip"
-  health_check {
-    interval            = 60
-    timeout             = 30
-    path                = "/"
-    port                = local.healthcheck_port
-    matcher             = "200"
-    healthy_threshold   = 2
-    unhealthy_threshold = 3
-  }
-
-  tags = local.default_tags
-
-  depends_on = [aws_lb.external]
-}
-
-resource "aws_lb_target_group" "swarm_wss" {
-  vpc_id      = var.vpc_id
-  name_prefix = "swwss-"
-  protocol    = "HTTP"
-  port        = local.swarm_wss_port
   target_type = "ip"
   health_check {
     interval            = 60
@@ -301,20 +280,6 @@ module "alb_internal" {
         healthy_threshold   = 2
         unhealthy_threshold = 3
       }
-    },
-    {
-      name_prefix      = "swwss-"
-      backend_protocol = "HTTP"
-      backend_port     = local.swarm_wss_port
-      target_type      = "ip"
-      health_check = {
-        interval            = 30
-        path                = "/"
-        port                = local.healthcheck_port
-        matcher             = "200"
-        healthy_threshold   = 2
-        unhealthy_threshold = 3
-      }
     }
   ]
 
@@ -329,6 +294,12 @@ module "alb_internal" {
       port               = local.gateway_port
       protocol           = "HTTP"
       target_group_index = 1
+      action_type        = "forward"
+    },
+    {
+      port               = local.swarm_tcp_port
+      protocol           = "HTTP"
+      target_group_index = 2
       action_type        = "forward"
     },
     {
@@ -360,10 +331,10 @@ module "alb_internal" {
       target_group_index = 1
     },
     {
-      port               = local.swarm_wss_port
+      port               = local.swarm_ws_port
       protocol           = "HTTPS"
       certificate_arn    = var.acm_certificate_arn
-      target_group_index = 4
+      target_group_index = 3
     }
   ] : []
 

--- a/modules/ecs/ipfs/locals.tf
+++ b/modules/ecs/ipfs/locals.tf
@@ -7,10 +7,9 @@ locals {
   gateway_port     = 9011
   healthcheck_port = 8011
   swarm_tcp_port   = 4010
-  swarm_ws_port    = 4011
-  swarm_wss_port   = 4012
+  swarm_ws_port    = var.use_ssl ? 4012 : 4011
 
-  announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_wss_port}/wss,/dns4/${local.domain_name_external}/tcp/${local.swarm_tcp_port}" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws,/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_tcp_port}"
+  announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_ws_port}/wss,/dns4/${local.domain_name_external}/tcp/${local.swarm_tcp_port}" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws,/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_tcp_port}"
   domain_name_external  = "ipfs-${var.base_namespace}-external.${var.domain}"
   domain_name_internal  = "ipfs-${var.base_namespace}-internal.${var.domain}"
 
@@ -46,13 +45,7 @@ locals {
     }
   ] : []
 
-  swarm_lb_external = var.use_ssl ? [
-    {
-      target_group_arn = aws_lb_target_group.swarm_wss.arn
-      container_name   = "ipfs"
-      container_port   = local.swarm_wss_port
-    }
-    ] : [
+  swarm_lb_external = [
     {
       target_group_arn = aws_lb_target_group.swarm_ws.arn
       container_name   = "ipfs"
@@ -67,9 +60,9 @@ locals {
       container_port   = local.swarm_tcp_port
     },
     {
-      target_group_arn = var.use_ssl ? module.alb_internal[0].target_group_arns[4] : module.alb_internal[0].target_group_arns[3]
+      target_group_arn = module.alb_internal[0].target_group_arns[3]
       container_name   = "ipfs"
-      container_port   = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
+      container_port   = local.swarm_ws_port
     }
   ] : []
 

--- a/modules/ecs/ipfs/locals.tf
+++ b/modules/ecs/ipfs/locals.tf
@@ -6,10 +6,10 @@ locals {
   api_port         = 5011
   gateway_port     = 9011
   healthcheck_port = 8011
-  swarm_port       = 4011
-  swarm_ws_port    = 4012
+  swarm_ws_port    = 4011
+  swarm_wss_port   = 4012
 
-  announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_ws_port}/wss" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws"
+  announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_wss_port}/wss,/dns4/${local.domain_name_external}/tcp/${local.swarm_ws_port}/ws" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws"
   domain_name_external  = "ipfs-${var.base_namespace}-external.${var.domain}"
   domain_name_internal  = "ipfs-${var.base_namespace}-internal.${var.domain}"
 

--- a/modules/ecs/ipfs/locals.tf
+++ b/modules/ecs/ipfs/locals.tf
@@ -10,7 +10,7 @@ locals {
   swarm_ws_port    = 4011
   swarm_wss_port   = 4012
 
-  announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_wss_port}/wss,/dns4/${local.domain_name_external}/tcp/${local.swarm_ws_port}/ws" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws"
+  announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_wss_port}/wss,/dns4/${local.domain_name_external}/tcp/${local.swarm_tcp_port}" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws,/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_tcp_port}"
   domain_name_external  = "ipfs-${var.base_namespace}-external.${var.domain}"
   domain_name_internal  = "ipfs-${var.base_namespace}-internal.${var.domain}"
 

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -59,9 +59,6 @@ resource "aws_ecs_task_definition" "main" {
       healthcheck_port      = local.healthcheck_port
       swarm_tcp_port        = local.swarm_tcp_port
       swarm_ws_port         = local.swarm_ws_port
-      swarm_wss_port        = local.swarm_wss_port
-      swarm_config_tcp_port = local.swarm_tcp_port
-      swarm_config_ws_port  = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
       announce_address_list = local.announce_address_list
       dht_server_mode       = var.dht_server_mode
       debug                 = var.debug

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -57,7 +57,8 @@ resource "aws_ecs_task_definition" "main" {
       api_port              = local.api_port
       gateway_port          = local.gateway_port
       healthcheck_port      = local.healthcheck_port
-      swarm_ws_port         = local.swarm_ws_port
+      swarm_tcp_port        = local.swarm_ws_port
+      swarm_ws_port         = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
       announce_address_list = local.announce_address_list
       dht_server_mode       = var.dht_server_mode
       debug                 = var.debug

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -49,17 +49,19 @@ resource "aws_ecs_task_definition" "main" {
       memory            = var.ecs_memory
       region            = var.aws_region
 
-      ceramic_network     = var.ceramic_network
-      enable_api          = true
-      enable_gateway      = true
-      enable_pubsub       = var.enable_pubsub
+      ceramic_network = var.ceramic_network
+      enable_api      = true
+      enable_gateway  = true
+      enable_pubsub   = var.enable_pubsub
 
       api_port              = local.api_port
       gateway_port          = local.gateway_port
       healthcheck_port      = local.healthcheck_port
-      swarm_tcp_port        = local.swarm_ws_port
-      swarm_ws_port         = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
+      swarm_tcp_port        = local.swarm_tcp_port
+      swarm_ws_port         = local.swarm_ws_port
       swarm_wss_port        = local.swarm_wss_port
+      swarm_config_tcp_port = local.swarm_tcp_port
+      swarm_config_ws_port  = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
       announce_address_list = local.announce_address_list
       dht_server_mode       = var.dht_server_mode
       debug                 = var.debug
@@ -67,7 +69,7 @@ resource "aws_ecs_task_definition" "main" {
       s3_bucket_name       = var.s3_bucket_name
       s3_access_key_id     = module.ecs_ipfs_task_user.this_iam_access_key_id
       s3_secret_access_key = module.ecs_ipfs_task_user.this_iam_access_key_secret
-      ipfs_path            = var.directory_namespace != "" ? "${var.directory_namespace}/ipfs" : "ipfs" 
+      ipfs_path            = var.directory_namespace != "" ? "${var.directory_namespace}/ipfs" : "ipfs"
       root_backend         = var.root_backend
       blocks_backend       = var.blocks_backend
       keys_backend         = var.keys_backend

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -59,6 +59,7 @@ resource "aws_ecs_task_definition" "main" {
       healthcheck_port      = local.healthcheck_port
       swarm_tcp_port        = local.swarm_ws_port
       swarm_ws_port         = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
+      swarm_wss_port        = local.swarm_wss_port
       announce_address_list = local.announce_address_list
       dht_server_mode       = var.dht_server_mode
       debug                 = var.debug

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -57,7 +57,6 @@ resource "aws_ecs_task_definition" "main" {
       api_port              = local.api_port
       gateway_port          = local.gateway_port
       healthcheck_port      = local.healthcheck_port
-      swarm_port            = local.swarm_port
       swarm_ws_port         = local.swarm_ws_port
       announce_address_list = local.announce_address_list
       dht_server_mode       = var.dht_server_mode

--- a/modules/ecs/ipfs/security_groups.tf
+++ b/modules/ecs/ipfs/security_groups.tf
@@ -25,15 +25,15 @@ resource "aws_security_group" "alb_external" {
   }
 
   ingress {
-    from_port   = local.swarm_ws_port
-    to_port     = local.swarm_ws_port
+    from_port   = local.swarm_tcp_port
+    to_port     = local.swarm_tcp_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   ingress {
-    from_port   = local.swarm_wss_port
-    to_port     = local.swarm_wss_port
+    from_port   = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
+    to_port     = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -51,7 +51,7 @@ resource "aws_security_group" "alb_external" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   egress {
     from_port   = 0
     to_port     = 0
@@ -89,15 +89,15 @@ resource "aws_security_group" "alb_internal" {
   }
 
   ingress {
-    from_port   = local.swarm_ws_port
-    to_port     = local.swarm_ws_port
+    from_port   = local.swarm_tcp_port
+    to_port     = local.swarm_tcp_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   ingress {
-    from_port   = local.swarm_wss_port
-    to_port     = local.swarm_wss_port
+    from_port   = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
+    to_port     = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -115,7 +115,7 @@ resource "aws_security_group" "alb_internal" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/modules/ecs/ipfs/security_groups.tf
+++ b/modules/ecs/ipfs/security_groups.tf
@@ -32,8 +32,8 @@ resource "aws_security_group" "alb_external" {
   }
 
   ingress {
-    from_port   = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
-    to_port     = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
+    from_port   = local.swarm_ws_port
+    to_port     = local.swarm_ws_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -96,8 +96,8 @@ resource "aws_security_group" "alb_internal" {
   }
 
   ingress {
-    from_port   = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
-    to_port     = var.use_ssl ? local.swarm_wss_port : local.swarm_ws_port
+    from_port   = local.swarm_ws_port
+    to_port     = local.swarm_ws_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/modules/ecs/ipfs/security_groups.tf
+++ b/modules/ecs/ipfs/security_groups.tf
@@ -30,6 +30,13 @@ resource "aws_security_group" "alb_external" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
+  ingress {
+    from_port   = local.swarm_wss_port
+    to_port     = local.swarm_wss_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   ingress {
     from_port   = 80
@@ -44,6 +51,7 @@ resource "aws_security_group" "alb_external" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
   egress {
     from_port   = 0
     to_port     = 0
@@ -86,6 +94,13 @@ resource "aws_security_group" "alb_internal" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
+  ingress {
+    from_port   = local.swarm_wss_port
+    to_port     = local.swarm_wss_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   ingress {
     from_port   = 80
@@ -100,6 +115,7 @@ resource "aws_security_group" "alb_internal" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
   egress {
     from_port   = 0
     to_port     = 0

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -15,7 +15,7 @@
                 "containerPort": ${healthcheck_port}
             },
             {
-                "containerPort": ${swarm_ws_port}
+                "containerPort": ${swarm_tcp_port}
             },
             {
                 "containerPort": ${swarm_wss_port}

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -18,6 +18,9 @@
                 "containerPort": ${swarm_tcp_port}
             },
             {
+                "containerPort": ${swarm_ws_port}
+            },
+            {
                 "containerPort": ${swarm_wss_port}
             }
         ],
@@ -108,11 +111,11 @@
             },
             {
                 "name": "IPFS_SWARM_TCP_PORT",
-                "value": "${swarm_tcp_port}"
+                "value": "${swarm_config_tcp_port}"
             },
             {
                 "name": "IPFS_SWARM_WS_PORT",
-                "value": "${swarm_ws_port}"
+                "value": "${swarm_config_ws_port}"
             },
             {
                 "name": "NODE_TLS_REJECT_UNAUTHORIZED",

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -19,9 +19,6 @@
             },
             {
                 "containerPort": ${swarm_ws_port}
-            },
-            {
-                "containerPort": ${swarm_wss_port}
             }
         ],
         "environment": [
@@ -111,11 +108,11 @@
             },
             {
                 "name": "IPFS_SWARM_TCP_PORT",
-                "value": "${swarm_config_tcp_port}"
+                "value": "${swarm_tcp_port}"
             },
             {
                 "name": "IPFS_SWARM_WS_PORT",
-                "value": "${swarm_config_ws_port}"
+                "value": "${swarm_ws_port}"
             },
             {
                 "name": "NODE_TLS_REJECT_UNAUTHORIZED",

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -108,7 +108,7 @@
             },
             {
                 "name": "IPFS_SWARM_TCP_PORT",
-                "value": "${swarm_ws_port}"
+                "value": "${swarm_tcp_port}"
             },
             {
                 "name": "IPFS_SWARM_WS_PORT",

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -15,10 +15,10 @@
                 "containerPort": ${healthcheck_port}
             },
             {
-                "containerPort": ${swarm_ws_port}
+                "containerPort": ${swarm_tcp_port}
             },
             {
-                "containerPort": ${swarm_wss_port}
+                "containerPort": ${swarm_ws_port}
             }
         ],
         "environment": [

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -15,10 +15,10 @@
                 "containerPort": ${healthcheck_port}
             },
             {
-                "containerPort": ${swarm_port}
+                "containerPort": ${swarm_ws_port}
             },
             {
-                "containerPort": ${swarm_ws_port}
+                "containerPort": ${swarm_wss_port}
             }
         ],
         "environment": [
@@ -108,7 +108,7 @@
             },
             {
                 "name": "IPFS_SWARM_TCP_PORT",
-                "value": "${swarm_port}"
+                "value": "${swarm_ws_port}"
             },
             {
                 "name": "IPFS_SWARM_WS_PORT",

--- a/modules/ecs/ipfs/templates/container_definitions.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions.json.tpl
@@ -15,10 +15,10 @@
                 "containerPort": ${healthcheck_port}
             },
             {
-                "containerPort": ${swarm_tcp_port}
+                "containerPort": ${swarm_ws_port}
             },
             {
-                "containerPort": ${swarm_ws_port}
+                "containerPort": ${swarm_wss_port}
             }
         ],
         "environment": [

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -64,7 +64,7 @@ module "ipfs" {
   s3_bucket_name          = data.aws_s3_bucket.main.id
   root_backend            = var.ipfs_root_backend
   blocks_backend          = var.ipfs_blocks_backend
-  datstore_backend        = var.ipfs_datastore_backend
+  datastore_backend       = var.ipfs_datastore_backend
   keys_backend            = var.ipfs_keys_backend
   pins_backend            = var.ipfs_pins_backend
   use_ssl                 = true


### PR DESCRIPTION
To ensure that Ceramic v1 nodes (js-ipfs) can reach and be reached by Ceramic v2 nodes (go-ipfs), we enable swarm connections over pure TCP in addition to websocket ports.

> _Ceramic v2 IPFS nodes can not connect to wss addresses until [support for secure websockets](https://github.com/libp2p/go-ws-transport/commit/d58294714ec497fba4619773886a606549144df4) is added to go-ipfs._

## SSL Enabled

IPFS nodes will be configured with swarm addresses

```go
/ip4/.../tcp/4010
/ip4/.../tcp/4012/ws
```

and they will announce addresses

```go
/dns4/.../tcp/4010         // Ceramic v2 IPFS nodes can connect to this address
/dns4/.../tcp/4012/wss     // but not this one
```

## SSL Disabled

IPFS nodes will be configured with swarm addresses

```go
/ip4/.../tcp/4010
/ip4/.../tcp/4011/ws
```

and they will announce addresses

```go
/dns4/.../tcp/4010        // Ceramic v2 IPFS nodes can connect to this address
/dns4/.../tcp/4011/ws     // and this one
```

## References
- See [Ceramic v1 ipfs-daemon config](https://github.com/ceramicnetwork/js-ceramic/blob/1.x-colorless/packages/ipfs-daemon/src/ipfs-daemon.ts#L167-L170)