### PR TITLE
feat: make ssm peer id and private key optional

### DIFF
--- a/examples/ecs/main.tf
+++ b/examples/ecs/main.tf
@@ -44,6 +44,7 @@ module "ceramic_ecs" {
   vpc_cidr_block                 = data.aws_vpc.main.cidr_block
   vpc_id                         = var.vpc_id
   vpc_security_group_id          = var.vpc_security_group_id
+  existing_ipfs_peer             = var.existing_ipfs_peers
 }
 
 /*

--- a/examples/ecs/variables.tf
+++ b/examples/ecs/variables.tf
@@ -148,3 +148,9 @@ variable "ipfs_default_log_level" {
   description = "IPFS default log level"
   default     = "info"
 }
+
+variable "existing_ipfs_peers" {
+  type        = string
+  description = "Restore existing IPFS peer identities"
+  default     = false
+}

--- a/modules/ecs/ipfs/locals.tf
+++ b/modules/ecs/ipfs/locals.tf
@@ -9,6 +9,8 @@ locals {
   swarm_tcp_port   = 4010
   swarm_ws_port    = 4011
 
+  task_definition = var.existing_peer ? aws_ecs_task_definition.td_existing_peer : aws_ecs_task_definition.td
+
   announce_address_list = var.use_ssl ? "/dns4/${local.domain_name_external}/tcp/${local.swarm_ws_port}/ws,/dns4/${local.domain_name_external}/tcp/${local.swarm_tcp_port}" : "/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_ws_port}/ws,/dns4/${aws_lb.external.dns_name}/tcp/${local.swarm_tcp_port}"
   domain_name_external  = "go-ipfs-${var.base_namespace}-external.${var.domain}"
   domain_name_internal  = "go-ipfs-${var.base_namespace}-internal.${var.domain}"

--- a/modules/ecs/ipfs/main.tf
+++ b/modules/ecs/ipfs/main.tf
@@ -2,7 +2,7 @@ resource "aws_ecs_service" "main" {
   platform_version       = "1.4.0"
   name                   = var.ecs_service_name
   cluster                = var.ecs_cluster_name
-  task_definition        = aws_ecs_task_definition.main.arn
+  task_definition        = var.existing_peer ? aws_ecs_task_definition.td_existing_peer.arn : aws_ecs_task_definition.td.arn
   desired_count          = var.ecs_count
   launch_type            = "FARGATE"
   enable_execute_command = true
@@ -32,7 +32,7 @@ resource "aws_ecs_service" "main" {
   depends_on = [
     aws_lb.external,
     module.alb_internal,
-    aws_ecs_task_definition.main,
+    local.task_definition,
     module.api_security_group,
     aws_security_group.alb_internal,
     aws_security_group.alb_external
@@ -43,7 +43,7 @@ resource "aws_ecs_service" "main" {
   }
 }
 
-resource "aws_ecs_task_definition" "main" {
+resource "aws_ecs_task_definition" "td" {
   family = local.namespace
   container_definitions = templatefile(
     "${path.module}/templates/container_definitions.json.tpl",
@@ -98,10 +98,78 @@ resource "aws_ecs_task_definition" "main" {
   tags = local.default_tags
 }
 
+resource "aws_ecs_task_definition" "td_existing_peer" {
+  family = local.namespace
+  container_definitions = templatefile(
+  "${path.module}/templates/container_definitions_existing_peer.json.tpl",
+  {
+    cpu               = var.ecs_cpu
+    env               = var.env
+    image             = data.docker_registry_image.ipfs.name
+    log_group         = var.ecs_log_group_name
+    log_stream_prefix = var.ecs_log_prefix
+    memory            = var.ecs_memory
+    region            = var.aws_region
+
+    enable_api     = true
+    enable_gateway = true
+    enable_pubsub  = var.enable_pubsub
+
+    api_port              = local.api_port
+    gateway_port          = local.gateway_port
+    healthcheck_port      = local.healthcheck_port
+    swarm_tcp_port        = local.swarm_tcp_port
+    swarm_ws_port         = local.swarm_ws_port
+    announce_address_list = local.announce_address_list
+    default_log_level     = local.default_log_level
+
+    repo_volume_source = "${local.namespace}-repo"
+
+    peer_id         = data.aws_ssm_parameter.peer_id[0].value
+    private_key_arn = data.aws_ssm_parameter.private_key[0].arn
+
+    s3_bucket_name       = var.s3_bucket_name
+    s3_region            = var.aws_region
+    s3_access_key_id     = module.ecs_ipfs_task_user.this_iam_access_key_id
+    s3_secret_access_key = module.ecs_ipfs_task_user.this_iam_access_key_secret
+    use_s3_blockstore    = var.use_s3_blockstore
+    s3_key_transform     = "next-to-last/2"
+    s3_root_directory    = var.directory_namespace != "" ? "${var.directory_namespace}/ipfs/blocks" : "ipfs/blocks"
+  }
+  )
+
+  execution_role_arn = module.ecs_task_execution_role.this_iam_role_arn
+  task_role_arn      = module.ecs_ipfs_task_role.this_iam_role_arn
+  network_mode       = "awsvpc"
+
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.ecs_cpu
+  memory                   = var.ecs_memory
+
+  volume {
+    name = "${local.namespace}-repo"
+    efs_volume_configuration {
+      file_system_id = module.efs_repo_volume.id
+    }
+  }
+
+  tags = local.default_tags
+}
+
 /*
  * Existing AWS resources (must be created beforehand).
  */
 
 data "aws_ecs_cluster" "main" {
   cluster_name = var.ecs_cluster_name
+}
+
+data "aws_ssm_parameter" "peer_id" {
+  count = var.existing_peer ? 1 : 0
+  name = "/${local.namespace}/peer_id"
+}
+
+data "aws_ssm_parameter" "private_key" {
+  count = var.existing_peer ? 1 : 0
+  name = "/${local.namespace}/private_key"
 }

--- a/modules/ecs/ipfs/templates/container_definitions_existing_peer.json.tpl
+++ b/modules/ecs/ipfs/templates/container_definitions_existing_peer.json.tpl
@@ -1,0 +1,129 @@
+[
+    {
+        "name": "go-ipfs",
+        "image": "${image}",
+        "cpu": ${cpu},
+        "memory": ${memory},
+        "linuxParameters": {
+            "initProcessEnabled": true
+        },
+        "ulimits": [
+            {
+                "name": "nofile",
+                "hardLimit": 1000000,
+                "softLimit": 1000000
+            }
+        ],
+        "mountPoints": [
+            {
+                "sourceVolume": "${repo_volume_source}",
+                "containerPath": "/data/ipfs"
+            }
+        ],
+        "portMappings": [
+            {
+                "containerPort": ${api_port}
+            },
+            {
+                "containerPort": ${gateway_port}
+            },
+            {
+                "containerPort": ${healthcheck_port}
+            },
+            {
+                "containerPort": ${swarm_tcp_port}
+            },
+            {
+                "containerPort": ${swarm_ws_port}
+            }
+        ],
+        "environment": [
+            {
+                "name": "IPFS_LOGGING",
+                "value": "${default_log_level}"
+            },
+            {
+                "name": "IPFS_ANNOUNCE_ADDRESS_LIST",
+                "value": "${announce_address_list}"
+            },
+            {
+                "name": "IPFS_API_PORT",
+                "value": "${api_port}"
+            },
+            {
+                "name": "IPFS_ENABLE_API",
+                "value": "${enable_api}"
+            },
+            {
+                "name": "IPFS_ENABLE_GATEWAY",
+                "value": "${enable_gateway}"
+            },
+            {
+                "name": "IPFS_ENABLE_HEALTHCHECK",
+                "value": "true"
+            },
+            {
+                "name": "IPFS_ENABLE_S3",
+                "value": "${use_s3_blockstore}"
+            },
+            {
+                "name": "IPFS_PEER_ID",
+                "value": "${peer_id}"
+            },
+            {
+                "name": "IPFS_GATEWAY_PORT",
+                "value": "${gateway_port}"
+            },
+            {
+                "name": "IPFS_HEALTHCHECK_PORT",
+                "value": "${healthcheck_port}"
+            },
+            {
+                "name": "IPFS_S3_ACCESS_KEY_ID",
+                "value": "${s3_access_key_id}"
+            },
+            {
+                "name": "IPFS_S3_SECRET_ACCESS_KEY",
+                "value": "${s3_secret_access_key}"
+            },
+            {
+                "name": "IPFS_S3_BUCKET_NAME",
+                "value": "${s3_bucket_name}"
+            },
+            {
+                "name": "IPFS_S3_KEY_TRANSFORM",
+                "value": "${s3_key_transform}"
+            },
+            {
+                "name": "IPFS_S3_REGION",
+                "value": "${s3_region}"
+            },
+            {
+                "name": "IPFS_S3_ROOT_DIRECTORY",
+                "value": "${s3_root_directory}"
+            },
+            {
+                "name": "IPFS_SWARM_TCP_PORT",
+                "value": "${swarm_tcp_port}"
+            },
+            {
+                "name": "IPFS_SWARM_WS_PORT",
+                "value": "${swarm_ws_port}"
+            }
+        ],
+        "secrets": [
+            {
+                "name": "IPFS_PRIVATE_KEY",
+                "valueFrom": "${private_key_arn}"
+            }
+        ],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "${log_group}",
+                "awslogs-region": "${region}",
+                "awslogs-stream-prefix": "${log_stream_prefix}"
+            }
+        }
+    }
+]

--- a/modules/ecs/ipfs/variables.tf
+++ b/modules/ecs/ipfs/variables.tf
@@ -167,3 +167,9 @@ variable "default_log_level" {
   description = "IPFS default log level"
   default     = "info"
 }
+
+variable "existing_peer" {
+  type        = string
+  description = "Restore existing IPFS peer identity"
+  default     = false
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -65,6 +65,7 @@ module "ipfs" {
   vpc_id                  = var.vpc_id
   vpc_security_group_id   = var.vpc_security_group_id
   efs_security_group_id   = module.ceramic.efs_security_group_id
+  existing_peer           = var.existing_ipfs_peer
 }
 
 resource "aws_cloudwatch_log_group" "ceramic" {

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -157,3 +157,9 @@ variable "ipfs_default_log_level" {
   description = "IPFS default log level"
   default     = "info"
 }
+
+variable "existing_ipfs_peer" {
+  type        = string
+  description = "Restore existing IPFS peer identity"
+  default     = false
+}


### PR DESCRIPTION
The current version of this module does not allow reusing existing IPFS peer IDs and private keys. As a result, any IPFS nodes created using the module will start with a clean slate and that partners who wish to reuse their existing IPFS identities will not be able to do so. 

The updates in this PR add support for using SSM to provide existing IPFS identities, if configured during the application of the module.