### PR TITLE
feat(ipfs): backup repo to s3 via datasync

### DIFF
--- a/modules/ecs/ipfs/data_sync.tf
+++ b/modules/ecs/ipfs/data_sync.tf
@@ -1,0 +1,60 @@
+# Must be scheduled via AWS
+resource "aws_datasync_task" "main" {
+  count                    = var.enable_repo_backup_to_s3 ? 1 : 0
+  source_location_arn      = aws_datasync_location_efs.efs_repo_volume[0].arn
+  destination_location_arn = aws_datasync_location_s3.s3_ipfs_repo[0].arn
+
+  name                     = "${local.namespace}-repo"
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.data_sync.arn # Must be enabled in AWS
+  options {
+    verify_mode = "NONE"
+    log_level   = "BASIC"
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_datasync_location_efs" "efs_repo_volume" {
+  count               = var.enable_repo_backup_to_s3 ? 1 : 0
+  efs_file_system_arn = data.aws_efs_mount_target.efs_repo_volume.file_system_arn
+
+  ec2_config {
+    security_group_arns = flatten([
+      module.efs_repo_volume.security_group_arn,
+      data.aws_security_groups.subnet.arns
+    ])
+    subnet_arn = data.aws_subnet.mount_target.arn
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_datasync_location_s3" "s3_ipfs_repo" {
+  count         = var.enable_repo_backup_to_s3 ? 1 : 0
+  s3_bucket_arn = var.s3_repo_backup_bucket_arn
+  subdirectory  = local.namespace
+
+  s3_config {
+    bucket_access_role_arn = module.s3_data_sync_role.this_iam_role_arn
+  }
+
+  tags = local.default_tags
+}
+
+data "aws_efs_mount_target" "efs_repo_volume" {
+  mount_target_id = module.efs_repo_volume.mount_target_ids[0]
+}
+
+data "aws_subnet" "mount_target" {
+  id = data.aws_efs_mount_target.efs_repo_volume.subnet_id
+}
+
+data "aws_security_groups" "subnet" {
+  filter {
+    name = "group-id"
+    values = [
+      var.efs_security_group_id,
+      var.vpc_security_group_id
+    ]
+  }
+}

--- a/modules/ecs/ipfs/templates/s3_data_sync_policy.json.tpl
+++ b/modules/ecs/ipfs/templates/s3_data_sync_policy.json.tpl
@@ -1,0 +1,27 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads"
+            ],
+            "Effect": "Allow",
+            "Resource": "${resource}"
+        },
+        {
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:ListMultipartUploadParts",
+                "s3:PutObjectTagging",
+                "s3:GetObjectTagging",
+                "s3:PutObject"
+            ],
+            "Effect": "Allow",
+            "Resource": "${resource}/*"
+        }
+    ]
+}

--- a/modules/ecs/ipfs/variables.tf
+++ b/modules/ecs/ipfs/variables.tf
@@ -116,6 +116,12 @@ variable "efs_security_group_id" {
 
 /* Specified */
 
+variable "default_log_level" {
+  type        = string
+  description = "IPFS default log level"
+  default     = "info"
+}
+
 variable "enable_alb_logging" {
   type        = bool
   description = "True to enable ALB logs (stored in a new S3 bucket)"
@@ -146,6 +152,11 @@ variable "enable_pubsub" {
   description = "True to enable IPFS PubSub"
 }
 
+variable "enable_repo_backup_to_s3" {
+  type        = bool
+  description = "True to backup IPFS repo to S3"
+}
+
 variable "directory_namespace" {
   type        = string
   description = "Directory for logs and state"
@@ -157,19 +168,18 @@ variable "image_tag" {
   description = "Image tag"
 }
 
-variable "use_s3_blockstore" {
-  type        = bool
-  description = "True for storing IPFS blocks in S3, false for storing them in an EFS volume"
-}
-
-variable "default_log_level" {
+variable "s3_repo_backup_bucket_arn" {
   type        = string
-  description = "IPFS default log level"
-  default     = "info"
+  description = "ARN of S3 bucket to use for IPFS repo backup"
 }
 
 variable "use_existing_peer_identity" {
   type        = string
   description = "Use existing IPFS peer identity"
   default     = false
+}
+
+variable "use_s3_blockstore" {
+  type        = bool
+  description = "True for storing IPFS blocks in S3, false for storing them in an EFS volume"
 }

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -52,6 +52,7 @@ module "ipfs" {
   enable_external_gateway    = false
   enable_internal_gateway    = false
   enable_pubsub              = true
+  enable_repo_backup_to_s3   = var.ipfs_enable_repo_backup_to_s3
   env                        = var.env
   image_tag                  = var.image_tag
   namespace                  = "${local.namespace}-ipfs-nd"
@@ -59,6 +60,7 @@ module "ipfs" {
   public_subnet_ids          = var.public_subnet_ids
   s3_bucket_arn              = data.aws_s3_bucket.main.arn
   s3_bucket_name             = data.aws_s3_bucket.main.id
+  s3_repo_backup_bucket_arn  = var.ipfs_s3_repo_backup_bucket_arn
   use_ssl                    = true
   use_s3_blockstore          = true
   vpc_cidr_block             = var.vpc_cidr_block

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -129,6 +129,12 @@ variable "ipfs_cpu" {
   default     = 1024 # 1024 = 1 vCPU
 }
 
+variable "ipfs_default_log_level" {
+  type        = string
+  description = "IPFS default log level"
+  default     = "info"
+}
+
 variable "ipfs_domain_name" {
   type        = string
   description = "Domain name, including TLD"
@@ -137,6 +143,12 @@ variable "ipfs_domain_name" {
 variable "ipfs_enable_alb_logging" {
   type        = bool
   description = "True to enable ALB logs (stored in a new S3 bucket)"
+  default     = false
+}
+
+variable "ipfs_enable_repo_backup_to_s3" {
+  type        = bool
+  description = "True to backup IPFS repo to S3"
   default     = false
 }
 
@@ -152,10 +164,10 @@ variable "ipfs_task_count" {
   default     = 1
 }
 
-variable "ipfs_default_log_level" {
+variable "ipfs_s3_repo_backup_bucket_arn" {
   type        = string
-  description = "IPFS default log level"
-  default     = "info"
+  description = "ARN of S3 bucket to use as a backup for the IPFS repo"
+  default     = ""
 }
 
 variable "use_existing_ipfs_peer_identity" {


### PR DESCRIPTION
Adds option to backup the IPFS repo stored in an EFS volume to an S3 bucket using AWS data sync.

Note: Data sync tasks must be scheduled manually in AWS console before they will run.