### PR TITLE
Increase resources for ceramic and ipfs

### DIFF
--- a/modules/ecs/ceramic/main.tf
+++ b/modules/ecs/ceramic/main.tf
@@ -50,6 +50,8 @@ resource "aws_ecs_task_definition" "main" {
     log_stream_prefix          = var.ecs_log_prefix
     logs_volume_source         = var.efs_logs_fs_name
     memory                     = var.ecs_memory
+    node_options               = var.node_options
+    pubsub_qps_limit           = var.pubsub_qps_limit
     region                     = var.aws_region
     s3_state_store_bucket_name = var.s3_bucket_name
     s3_access_key_id           = module.s3_ceramic_state_store_task_user.this_iam_access_key_id

--- a/modules/ecs/ceramic/templates/container_definitions.json.tpl
+++ b/modules/ecs/ceramic/templates/container_definitions.json.tpl
@@ -44,9 +44,17 @@
         ],
         "environment": [
             {
+                "name": "CERAMIC_PUBSUB_QPS_LIMIT",
+                "value": "${pubsub_qps_limit}"
+            }
+            {
                 "name": "NODE_ENV",
                 "value": "production"
             },
+            {
+                "name": "NODE_OPTIONS",
+                "value": "${node_options}"
+            },            
             {
                 "name": "AWS_ACCESS_KEY_ID",
                 "value": "${s3_access_key_id}"

--- a/modules/ecs/ceramic/variables.tf
+++ b/modules/ecs/ceramic/variables.tf
@@ -75,7 +75,7 @@ variable "ecs_cpu" {
 variable "ecs_memory" {
   type        = number
   description = "Memory to allocate to the Ceramic daemon ECS task"
-  default     = 2048 # 2048 MiB = 2 GB
+  default     = 8192 # 8192 MiB = 8 GB
 }
 
 variable "ecs_service_name" {
@@ -138,6 +138,12 @@ variable "namespace" {
   description = "Namespace for Ceramic resources"
 }
 
+variable "node_options" {
+  type        = string
+  description = "NodeJS options"
+  default     = "--max-old-space-size=7500"
+}
+
 variable "private_subnet_ids" {
   type        = list(string)
   description = "List of private subnet ids for the VPC"
@@ -156,6 +162,12 @@ variable "s3_bucket_arn" {
 variable "s3_bucket_name" {
   type        = string
   description = "Name (aka id) of S3 bucket to use as a backend"
+}
+
+variable "pubsub_qps_limit" {
+  type = string
+  description = "Ceramic pubsub qps limit env value"
+  default = "50"
 }
 
 variable "vpc_security_group_id" {

--- a/modules/ecs/ipfs/variables.tf
+++ b/modules/ecs/ipfs/variables.tf
@@ -37,7 +37,7 @@ variable "ecs_cluster_name" {
 
 variable "ecs_cpu" {
   type        = number
-  description = "Fargate vCPU threads allocated to the Ceramic gateway instance"
+  description = "Fargate vCPU threads allocated to the IPFS instance"
 }
 
 variable "ecs_log_group_name" {
@@ -51,7 +51,8 @@ variable "ecs_log_prefix" {
 
 variable "ecs_memory" {
   type        = number
-  description = "Fargate memory allocated to the Ceramic gateway instance"
+  description = "Fargate memory allocated to the IPFS instance"
+  default     = 8192 # 8192 MiB = 8 GB
 }
 
 variable "ecs_service_name" {


### PR DESCRIPTION
# Update Terraform with CyberConnect suggestions - PLAT-784

## Description

Increase the default resource available to the ceramic and ipfs nodes.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ x ] `terraform validate`
- [ ] `terraform plan`

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

CyberConnect shared suggestions [here](https://threebox.notion.site/CyberConnect-Issue-mitigation-2a7890e1c0574af7b182d1c0931e704a) on how to improve performance, including increasing memory.
